### PR TITLE
update CSI plugins kubernetes compatibility

### DIFF
--- a/csi/azure/CHANGELOG.md
+++ b/csi/azure/CHANGELOG.md
@@ -11,3 +11,4 @@
 
 * Added support for Azure CSI v0.1
 * Basic support for interfacing with Azure Block Storage
+* Supports Kubernetes v1.10.x - v1.11.x

--- a/csi/digitalocean/CHANGELOG.md
+++ b/csi/digitalocean/CHANGELOG.md
@@ -2,17 +2,29 @@
 
 ## Versions
 
+- [v0.3.0](#v030)
+  - [Features](#features-for-v030)
+
 - [v0.2.0](#v020)
   - [Features](#features-for-v020)
 
 - [v0.1.1](#v011)
   - [Features](#features-for-v011)
 
+## v0.3.0
+
+### Features for v0.3.0
+
+* Added support for [DigitalOcean CSI v0.3.0](https://github.com/digitalocean/csi-digitalocean/blob/v0.3.0/CHANGELOG.md)
+* Supports Kubernetes >= v1.12.X
+
+
 ## v0.2.0
 
 ### Features for v0.2.0
 
 * Added support for [DigitalOcean CSI v0.2.0](https://github.com/digitalocean/csi-digitalocean/blob/v0.2.0/CHANGELOG.md#v020---20180905)
+* Supports Kubernetes v1.10.5 - v1.11.x
 
 ## v0.1.1
 
@@ -20,3 +32,4 @@
 
 * Added support for DigitalOcean CSI v0.1.1
 * Basic support for interfacing with DO Block Storage
+* Supports Kubernetes v1.10.x - v1.11.x

--- a/csi/google_cloud_platform/CHANGELOG.md
+++ b/csi/google_cloud_platform/CHANGELOG.md
@@ -13,10 +13,12 @@
 ### Features for v0.1.1
 
 * Added support for Google CSI v0.1.0.alpha
+* Supports Kubernetes v1.10.x - v1.11.x
 
-## v0.1.0
+## ~~v0.1.0~~ (Deprecated)
 
 ### Features for v0.1.0
 
 * Added support for Google CSI v0.1.0
 * Basic support for interfacing with Google Block Storage
+* Supports Kubernetes v1.10.x - v1.11.x


### PR DESCRIPTION
##Description
Updated CSI plugins to say which versions of kubernetes they support. 

Added changelog for the new 0.3.0 Digitalocean CSI. 

