### PR TITLE
Add new plugin cerebral autoscaler changelog

### DIFF
--- a/autoscaler/cerebral/CHANGELOG.md
+++ b/autoscaler/cerebral/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Autoscaler - [Cerebral](https://github.com/containership/cerebral) Changelog
+
+## Versions
+
+- [v0.1.0-alpha](#v010alpha)
+  - [Features](#features-for-v010alpha)
+
+## v0.1.0-alpha
+
+* Kubernetes cluster autoscaler with pluggable metrics backends and scaling engines
+* Support for Kubernetes v1.11 - v1.12
+* Requires `containership` cluster-management and `prometheus` metrics plugins
+  * `containership` cluster-management plugin >= v4.2.0
+  * `prometheus` metrics plugin >= v1.0.0
+* Prometheus metrics backend with cpu percent utilization, memory percent utilization and custom queries


### PR DESCRIPTION
### Description 
Adds Containership's newest plugin type `Autoscaler` with the implementation of `Cerebral` to the changelog. 

### Additional Considerations 
Do we want to make it more clear that this plugin is in alpha phase and is not ready for production? Or is having the version with `alpha` clear enough? 

Fixes: https://github.com/containership/plugins-changelog/issues/27