### PR TITLE
Add new plugin kubernetes metrics changelog

### DIFF
--- a/metrics/kubernetes/CHANGELOG.md
+++ b/metrics/kubernetes/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Metrics - Kubernetes Changelog
+
+## Versions
+
+- [v1.0.0](#v100)
+  - [Features](#features-for-v100)
+
+## v1.0.0
+
+### Features for v1.0.0
+
+* Support for fetching metrics through the built in [Kubernetes Metrics API](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/) server routes


### PR DESCRIPTION
### Description
Adds Containership's newest plugin type `Metrics` with the implementation of `Kubernetes` to the changelog. This is just a shim for the kubernetes metrics api already running on the clusters.